### PR TITLE
Introduce action-release-by-pr-label

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,30 @@
+name: "Tests"
+env:
+  GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
+
+jobs:
+  Test:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: mfinelli/setup-shfmt@v3
+      - name: actionlint
+        uses: raven-actions/actionlint@v1
+      - name: Run Lint
+        run: make lint
+      - name: Setup BATS
+        uses: mig4/setup-bats@v1
+        with:
+          bats-version: 1.5.0
+      - name: Run Tests
+        run: bats --trace --print-output-on-failure test/
+
+on:
+  workflow_call:
+    secrets:
+      PULUMI_BOT_TOKEN:
+        required: true
+  pull_request:
+    branches:
+      - master

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -1,0 +1,75 @@
+name: Verify
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  PR: 1
+  VERSION: "v0.0.1"
+  SHA: 8de77745e9d0022317fdc3efe30e4a785f93a329
+concurrency: integration_on_live_PRs
+jobs:
+  test:
+    uses: ./.github/workflows/tests.yml
+    secrets: inherit
+  integration:
+    name: integration test
+    runs-on: ubuntu-latest
+    steps:
+      # preconditions
+      - name: Checkout Scripts Repo
+        uses: actions/checkout@v3
+      - name: Unshallow clone for tags
+        run: git fetch --prune --unshallow --tags
+      - name: Label not present
+        run: gh pr edit "$PR" --repo="$GITHUB_REPOSITORY" --remove-label "needs-release/$VERSION" || true
+      - name: Tag is not present
+        run: git push -d origin "v0.0.1" || true
+
+      # simulate /release command
+      - name: Should release PR
+        uses: pulumi/action-release-by-pr-label@main
+        with:
+          command: "should-release"
+          repo: ${{ github.repository }}
+          pr: ${{ env.PR }}
+          version: ${{ env.VERSION }}
+        env:
+          RELEASE_BOT_ENDPOINT: ${{ secrets.RELEASE_BOT_ENDPOINT }}
+          RELEASE_BOT_KEY: ${{ secrets.RELEASE_BOT_KEY }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Check label was added
+        run: |
+          src/pr-need-release-labels.sh --repo="$GITHUB_REPOSITORY" "--pr=$PR" | grep "$VERSION"
+
+      # simulate post-main/master job flagging release bot
+      - name: check if this commit needs release
+        uses: pulumi/action-release-by-pr-label@main
+        with:
+          command: "release-if-needed"
+          repo: ${{ github.repository }}
+          commit: ${{ env.SHA }}
+          slack_channel: ${{ secrets.RELEASE_OPS_STAGING_SLACK_CHANNEL }}
+        env:
+          RELEASE_BOT_ENDPOINT: ${{ secrets.RELEASE_BOT_ENDPOINT }}
+          RELEASE_BOT_KEY: ${{ secrets.RELEASE_BOT_KEY }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Check tag was added
+        run: git fetch origin "refs/tags/$VERSION":"refs/tags/$VERSION" && git rev-parse "$VERSION"
+
+      # simulate post-release job label cleanup
+      - name: Clean up release labels
+        uses: pulumi/action-release-by-pr-label@main
+        with:
+          command: "clean-up-release-labels"
+          repo: ${{ github.repository }}
+          commit: ${{ env.SHA }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # clean up
+      - name: Remove tag
+        run: git push -d origin "v0.0.1" || true
+
+
+on:
+  push:
+    branches:
+    - main

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,11 @@
+ROOT_DIR := $(dir $(realpath $(lastword $(MAKEFILE_LIST))))
+
+lint:
+	"${ROOT_DIR}lint/shfmt.sh" "${ROOT_DIR}"
+	"${ROOT_DIR}lint/shellcheck.sh" "${ROOT_DIR}"
+	"${ROOT_DIR}lint/actionlint.sh" "${ROOT_DIR}"
+
+test:
+	bats --trace --print-output-on-failure "${ROOT_DIR}test/"
+
+.PHONY: lint test

--- a/README.md
+++ b/README.md
@@ -1,2 +1,202 @@
-# action-release-by-pr-label
-A github action for managing releases based on labels applied to PRs
+[![Verify](https://github.com/pulumi/action-release-by-pr-label/actions/workflows/verify.yml/badge.svg)](https://github.com/pulumi/action-release-by-pr-label/actions/workflows/verify.yml)
+
+# Release by PR Label
+GitHub actions to facilitate marking PRs as needing release using labels
+and then triggering releases from those labels at a later point.
+
+1. Use 'should-release' command to mark a PR (with a label) as needing release
+2. Use 'release-if-needed' after doing the work to verify a commit is ok to begin release (eg. at end of main/master build)
+3. Use 'clean-up-release-labels' after a release build to remove labels from the PRs that were released
+
+The advantages of this workflow are:
+1. You can fully automate release after a PR is merged
+2. What to release and what version number to use is still a human determination
+3. needs-release/* labels provide visibility into what PRs are awaiting release, and assist in debugging the release process
+
+
+## Configuration
+
+### Environment Variables (`env`)
+
+#### `RELEASE_BOT_ENDPOINT` (required)
+Create secret to hold the http endpoint for invoking release-bot
+
+    env:
+      RELEASE_BOT_ENDPOINT: ${{ secrets.RELEASE_BOT_ENDPOINT }}
+
+#### `RELEASE_BOT_KEY` (required)
+Create secret to hold the private key signing requests to release-bot
+
+    env:
+      RELEASE_BOT_KEY: ${{ secrets.RELEASE_BOT_KEY }}
+
+#### `GITHUB_TOKEN` (required)
+A github token for the user that will be used to add/remove labels
+
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+### Input Parameters (`with`)
+
+#### `command` (required)
+The command to run. Either "should-release", "release-if-needed", or "clean-up-release-labels"
+
+#### `repo` 
+The repository to operate on
+
+    default: ${{ github.repository }}
+
+#### `pr`
+The pr to mark for release (only required for "should-release")
+
+#### `version`
+The version to release the pr under (only required for "should-release")
+
+#### `commit`
+The commit to (possibly) release for "release-if-needed", or that was released for "clean-up-release-labels"
+
+#### `slack_channel`
+Optional slack channel for relase-bot to announce on
+
+## Detailed Example
+Use peter-evans/slash-command-dispatch to trigger a workflow when a trusted user comments 
+with "/release <VERSION>"
+```
+name: command-dispatch
+jobs:
+  command-dispatch-for-testing:
+    name: command-dispatch-for-testing
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - uses: peter-evans/slash-command-dispatch@v2
+      with:
+        commands: |
+          release
+        issue-type: pull-request
+        permission: write
+        reaction-token: ${{ secrets.GITHUB_TOKEN }}
+        repository: pulumi/pulumi-temp-test-provider
+        token: ${{ secrets.PULUMI_BOT_TOKEN }}
+on:
+  issue_comment:
+    types:
+    - created
+    - edited
+```
+
+In the release_command workflow triggered by the slash command, use the 'should-release' command 
+from this action to set the correct "needs-release/<VERSION>" label (or immediately tag if the PR
+is already merged and built)
+
+```
+name: release-command
+on:
+  repository_dispatch:
+    types:
+    - release-command
+jobs:
+  should_release:
+    name: Should release PR
+    runs-on: ubuntu-latest
+    steps:
+    - name: Should release PR
+      uses: pulumi/action-release-by-pr-label@main
+      with:
+        command: "should-release"
+        repo: ${{ github.repository }}
+        pr: ${{ github.event.client_payload.pull_request.number }}
+        version: ${{ github.event.client_payload.slash_command.args.all }}
+        slack_channel: ${{ secrets.RELEASE_OPS_STAGING_SLACK_CHANNEL }}
+      env:
+        RELEASE_BOT_ENDPOINT: ${{ secrets.RELEASE_BOT_ENDPOINT }}
+        RELEASE_BOT_KEY: ${{ secrets.RELEASE_BOT_KEY }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+```
+
+In your default branch build, use this action's 'release-if-needed' command to invoke release bot
+to tag the build when there is a needs-release/* label attached to the PR for the commit that was just built
+```
+jobs:
+  ...
+  check_for_needs_release:
+    name: check for needs-release
+    needs: final_default_branch_built_or_test_job
+    runs-on: ubuntu-latest
+    steps:
+    - name: check if this commit needs release
+      uses: pulumi/action-release-by-pr-label@main
+      with:
+        command: "release-if-needed"
+        repo: ${{ github.repository }}
+        commit: ${{ github.sha }}
+        slack_channel: ${{ secrets.RELEASE_OPS_STAGING_SLACK_CHANNEL }}
+      env:
+        RELEASE_BOT_ENDPOINT: ${{ secrets.RELEASE_BOT_ENDPOINT }}
+        RELEASE_BOT_KEY: ${{ secrets.RELEASE_BOT_KEY }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+name: main
+on:
+  push:
+    branches:
+    - main
+```
+
+Finally use this action's clean-up-release-labels at the end of your release job to remove
+the needs-release/* labels for any PRs that were released.
+
+```
+jobs:
+  ...
+  clear_need_release_labels:
+    name: Clean up release labels
+    needs: final_release_step
+    runs-on: ubuntu-latest
+    steps:
+    - name: Clean up release labels
+      uses: pulumi/action-release-by-pr-label@main
+      with:
+        command: "clean-up-release-labels"
+        repo: ${{ github.repository }}
+        commit: ${{ github.sha }}
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+name: release
+on:
+  push:
+    tags:
+    - v*.*.*
+    - "!v*.*.*-**"
+```
+
+
+``` mermaid
+flowchart TD
+    subgraph release_workflow
+        K[build release] -->L{does this release satisfy\nany needs-release/* labels}
+        L---|yes|M[remove labels]
+        L---|no|N[Done]
+    end
+    subgraph RELEASE_BOT
+        Handler ---> TAG
+        TAG(New Release Tag) --> K
+    end
+
+    subgraph release_command
+        B(command_release) --> C{already_merged_and_built?}
+        C -->|yes| D[invoke release-bot]
+        C -->|no| E[add needs-release/$VERISON label]
+        D ---| /tag_release|Handler
+    end
+    subgraph main_master_build
+        F[main/master build] ---> G(check-for-needs-release)
+        G --> H{PR for this commit has\n needs-release/* label?}
+        H ---|no|I[done]
+        H ---|yes|J[Invoke release bot]
+        J ---| /tag_release |Handler
+    end
+    CMD( /release $VERSION) ---|command_runner|B
+    MERGE(PR merges)--->F
+```

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,39 @@
+name: Release by PR label
+description: GitHub actions to facilitate marking PRs as needing release using labels and then triggering releases from those labels at a later point
+
+inputs:
+  command:
+    description: The command to run. Either "should-release", "release-if-needed", or "clean-up-release-labels"
+    required: true
+  repo:
+    description: The repository to operate on
+    default: ${{ github.repository }}
+    required: false
+  pr:
+    description: The pr to mark for release (only required for "should-release")
+    required: false
+  version:
+    description: The version to release the pr under (only required for "should-release")
+    required: false
+  commit:
+    description: The commit to (possibly) release for "release-if-needed", or that was released for "clean-up-release-labels"
+    required: false
+  slack_channel:
+    description: Optional slack channel for relase-bot to announce on
+    required: false
+
+runs:
+  using: composite
+  steps:
+    - if: inputs.command == 'should-release'
+      name: Should release
+      shell: bash
+      run: ${GITHUB_ACTION_PATH}/src/should-release.sh --repo=${{ inputs.repo }} --pr=${{ inputs.pr }} --version=${{ inputs.version }} --release-bot-key="$RELEASE_BOT_KEY" --release-bot-endpoint="$RELEASE_BOT_ENDPOINT" --slack-channel=${{ inputs.slack_channel }}
+    - if: inputs.command == 'release-if-needed'
+      name: Release if needed
+      shell: bash
+      run: ${GITHUB_ACTION_PATH}/src/release-if-needed.sh --repo=${{ inputs.repo }} --commit=${{ inputs.commit }} --release-bot-key="$RELEASE_BOT_KEY" --release-bot-endpoint="$RELEASE_BOT_ENDPOINT" --slack-channel=${{ inputs.slack_channel }}
+    - if: inputs.command == 'clean-up-release-labels'
+      name: Clean up release labels
+      shell: bash
+      run: ${GITHUB_ACTION_PATH}/src/remove-needs-release-labels-for-commit.sh --repo=${{ inputs.repo }} --commit=${{ inputs.commit }}

--- a/devbox.json
+++ b/devbox.json
@@ -1,0 +1,17 @@
+{
+  "packages": [
+    "shfmt@latest",
+    "shellcheck@latest",
+    "actionlint@latest"
+  ],
+  "shell": {
+    "init_hook": [
+      "echo 'Welcome to devbox!' > /dev/null"
+    ],
+    "scripts": {
+      "test": [
+        "echo \"Error: no test specified\" && exit 1"
+      ]
+    }
+  }
+}

--- a/devbox.lock
+++ b/devbox.lock
@@ -1,0 +1,23 @@
+{
+  "lockfile_version": "1",
+  "packages": {
+    "actionlint@latest": {
+      "last_modified": "2023-09-19T14:14:51Z",
+      "resolved": "github:NixOS/nixpkgs/8b5ab8341e33322e5b66fb46ce23d724050f6606#actionlint",
+      "source": "devbox-search",
+      "version": "1.6.25"
+    },
+    "shellcheck@latest": {
+      "last_modified": "2023-09-19T14:14:51Z",
+      "resolved": "github:NixOS/nixpkgs/8b5ab8341e33322e5b66fb46ce23d724050f6606#shellcheck",
+      "source": "devbox-search",
+      "version": "0.9.0"
+    },
+    "shfmt@latest": {
+      "last_modified": "2023-09-19T14:14:51Z",
+      "resolved": "github:NixOS/nixpkgs/8b5ab8341e33322e5b66fb46ce23d724050f6606#shfmt",
+      "source": "devbox-search",
+      "version": "3.7.0"
+    }
+  }
+}

--- a/lint/actionlint.sh
+++ b/lint/actionlint.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+set -euo pipefail
+
+DIR="$1/.github/workflows"
+if command -v actionlint >/dev/null 2>&1; then
+  echo "Running actionlint on $DIR/*.(yaml|yml)"
+  find "$DIR" -type f -name '*.yml' -exec actionlint {} +
+  find "$DIR" -type f -name '*.yaml' -exec actionlint {} +
+else
+  echo "actionlint is not installed. Skipping shell script formatting."
+  echo "Follow instructions here to install: https://github.com/rhysd/actionlint/blob/main/docs/install.md"
+  echo "or use 'devbox shell' (https://www.jetpack.io/devbox/docs/quickstart/)"
+  if [ -n "$CI" ]; then
+    exit 1
+  fi
+fi

--- a/lint/shellcheck.sh
+++ b/lint/shellcheck.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+set -euo pipefail
+
+DIR="$1"
+if command -v shellcheck >/dev/null 2>&1; then
+  if ! find "$DIR" -type f -name '*.sh' -exec false {} + >/dev/null 2>&1; then
+    echo "Running shellcheck on $DIR/**/*.sh"
+    find "$DIR" -type f -name '*.sh' -exec shellcheck -s bash {} +
+  fi
+  if [ -f "$DIR"/Makefile ]; then
+    echo "Running shellcheck on $DIR/Makefile"
+    # We unset Make related variables so that we can check the Makefile's dry-run output without
+    # Make thinking it's running recursively.
+    (
+      unset MAKELEVEL MAKEFLAGS MFLAGS
+      make -f "$DIR"/Makefile -n | shellcheck -s bash -
+    )
+  fi
+else
+  echo "shellcheck is not installed. Skipping shell script linting."
+  echo "Follow instructions here to install: https://github.com/koalaman/shellcheck#installing"
+  echo "or use 'devbox shell' (https://www.jetpack.io/devbox/docs/quickstart/)"
+  if [ -n "$CI" ]; then
+    exit 1
+  fi
+fi

--- a/lint/shfmt.sh
+++ b/lint/shfmt.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+set -euo pipefail
+
+DIR="$1"
+if command -v shfmt >/dev/null 2>&1; then
+  echo "runing shfmt on '$DIR/**/*.sh'"
+  shfmt -f "$DIR" | xargs shfmt -w -s -i 2
+else
+  echo "shfmt is not installed. Skipping shell script formatting."
+  echo "Follow instructions here to install: https://github.com/patrickvane/shfmt"
+  echo "or use 'devbox shell' (https://www.jetpack.io/devbox/docs/quickstart/)"
+  if [ -n "$CI" ]; then
+    exit 1
+  fi
+fi

--- a/src/add-needs-release-label-to-pr.sh
+++ b/src/add-needs-release-label-to-pr.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+set -euo pipefail
+
+die() {
+  echo Usage: "$0" "--repo=<REPO> --pr=<PR> --version=<VERSION>"
+  exit 1
+}
+
+for i in "$@"; do
+  case $i in
+  -r=* | --repo=*)
+    repo="${i#*=}"
+    ;;
+  -p=* | --pr=*)
+    pr="${i#*=}"
+    ;;
+  -v=* | --version=*)
+    version="${i#*=}"
+    ;;
+  *)
+    echo "unknown option $i"
+    die
+    ;;
+  esac
+done
+
+if [ -z "${repo-}" ] || [ -z "${pr-}" ] || [ -z "${version-}" ]; then
+  die
+fi
+
+label="needs-release/$version"
+
+# Force create is the easiest way to ensure the label exists, add a color just to keep it stable
+gh label create "$label" --repo "$repo" --force --color '#BFD4F2'
+
+gh pr edit "$pr" --repo "$repo" --add-label "$label"

--- a/src/check-if-commit-needs-release.sh
+++ b/src/check-if-commit-needs-release.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+set -euo pipefail
+
+die() {
+  echo Usage: "$0" "--repo=<REPO> --commit=<SHA>"
+  exit 1
+}
+
+for i in "$@"; do
+  case $i in
+  -r=* | --repo=*)
+    repo="${i#*=}"
+    ;;
+  -c=* | --commit=*)
+    commit="${i#*=}"
+    ;;
+  *)
+    echo "unknown option $i"
+    die
+    ;;
+  esac
+done
+
+if [ -z "${repo-}" ] || [ -z "${commit-}" ]; then
+  die
+fi
+
+# Extract the labels of merged PRs associated with this commit
+# and filter for the first label that has the "needs-release/" prefix
+gh pr list \
+  --repo "$repo" \
+  --state merged \
+  --search "$commit" \
+  --json labels --jq '.[].labels[].name' ||
+  echo "" |
+  grep -o "^needs-release/.*$" |
+    head -n 1

--- a/src/invoke_tag_release.sh
+++ b/src/invoke_tag_release.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+set -euo pipefail
+
+die() {
+  echo Invoke the \`/tag_release\` endpoint on release bot to tag a version of on the specified repo
+  echo Usage: "$0" "--repo=<REPO> --version=<VERSION> --key=<KEY> --endpoint=<ENDPOINT> [--channel=<CHANNEL>]"
+  exit 1
+}
+
+for i in "$@"; do
+  case $i in
+  -r=* | --repo=*)
+    repo="${i#*=}"
+    ;;
+  -k=* | --key=*)
+    key="${i#*=}"
+    ;;
+  -v=* | --version=*)
+    version="${i#*=}"
+    ;;
+  -e=* | --endpoint=*)
+    endpoint="${i#*=}"
+    ;;
+  -c=* | --channel=*)
+    channel="${i#*=}"
+    ;;
+  *)
+    echo "unknown option $i"
+    die
+    ;;
+  esac
+done
+
+if [ -z "${repo-}" ] || [ -z "${key-}" ] || [ -z "${version-}" ] || [ -z "${endpoint:-}" ]; then
+  die
+fi
+
+if ! echo "$repo" | grep '^pulumi/.*$'; then
+  echo release bot can only operate on repos in the pulumi org
+  echo include the 'pulumi/' prefix in the repo name
+  die
+fi
+repo=${repo#"pulumi/"}
+
+tempdir=$(mktemp -d)
+cd "$tempdir"
+trap 'rm -rf "$tempdir"; cd -' EXIT
+
+maybe_channel=""
+if [ -n "${channel-}" ]; then
+  maybe_channel=", 'channel':'$channel'"
+fi
+
+echo -n "{'repo': '$repo', 'version':'$version', 'timestamp':'$(date +%s)'$maybe_channel}" |
+  tr "'" '"' >body
+
+echo "$key" >private_key.pem
+openssl dgst -sha256 -sign private_key.pem -hex <body >sig
+rm private_key.pem
+
+# some versions of openssl add this prefix which we don't need
+sed -e 's/SHA2-256(stdin)= //g' -i".bak" sig
+
+curl -v -X POST \
+  --header "Content-Type: application/json" \
+  --header "X-Signature: $(cat sig)" \
+  --data-binary @body \
+  "$endpoint/tag_release"

--- a/src/is-pr-merge-commit-ancestor-of-commit.sh
+++ b/src/is-pr-merge-commit-ancestor-of-commit.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+set -euo pipefail
+
+die() {
+  echo Usage: "$0" "--repo=<REPO> --pr=<PR> --commit=<SHA>"
+  exit 1
+}
+
+for i in "$@"; do
+  case $i in
+  -r=* | --repo=*)
+    repo="${i#*=}"
+    ;;
+  -c=* | --commit=*)
+    commit="${i#*=}"
+    ;;
+  -p=* | --pr=*)
+    pr="${i#*=}"
+    ;;
+  *)
+    echo "unknown option $i"
+    die
+    ;;
+  esac
+done
+
+if [ -z "${repo-}" ] || [ -z "${commit-}" ] || [ -z "${pr:-}" ]; then
+  die
+fi
+gh auth status
+
+# check that the right repo is checked out
+if [[ $(git remote get-url origin | grep -c "$repo\(\.git\)\?$") -lt 1 ]]; then
+  echo "must be run from a checkout of $repo"
+  exit 1
+fi
+
+# make sure we have the history for the target commit
+git fetch origin "$commit"
+
+merge_commit=$(gh pr view "$pr" --repo "$repo" --json mergeCommit --jq ".mergeCommit.oid")
+if git merge-base --is-ancestor "$merge_commit" "$commit"; then
+  exit 0
+else
+  exit 2
+fi

--- a/src/pr-need-release-labels.sh
+++ b/src/pr-need-release-labels.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+set -euo pipefail
+
+die() {
+  echo "Get needs-release/* labels for a pr"
+  echo Usage: "$0" "--repo=<REPO> --pr=<PR>"
+  exit 1
+}
+
+for i in "$@"; do
+  case $i in
+  -r=* | --repo=*)
+    repo="${i#*=}"
+    ;;
+  -p=* | --pr=*)
+    pr="${i#*=}"
+    ;;
+  *)
+    echo "unknown option $i"
+    die
+    ;;
+  esac
+done
+
+if [ -z "${repo-}" ] || [ -z "${pr:-}" ]; then
+  die
+fi
+
+gh pr view "$pr" --repo "$repo" --json labels --jq '.[].[].name' || echo "" | grep -o "^needs-release/.*$" || echo ""

--- a/src/release-if-needed.sh
+++ b/src/release-if-needed.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+set -euo pipefail
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+die() {
+  echo Check if there is a PR associated with this commit with a needs-release/* tag
+  echo "   and invoke release-bot to release if needed"
+  echo Usage: "$0" "--repo=<REPO> --commit=<SHA> --release-bot-key=<KEY> --release-bot-endpoint=<ENDPOINT> [--slack-channel=<CHANNEL>]"
+  exit 1
+}
+
+for i in "$@"; do
+  case $i in
+  -r=* | --repo=*)
+    repo="${i#*=}"
+    ;;
+  -c=* | --commit=*)
+    commit="${i#*=}"
+    ;;
+  -k=* | --release-bot-key=*)
+    key="${i#*=}"
+    ;;
+  -e=* | --release-bot-endpoint=*)
+    endpoint="${i#*=}"
+    ;;
+  -s=* | --slack-channel=*)
+    channel="${i#*=}"
+    ;;
+  *)
+    echo "unknown option $i"
+    die
+    ;;
+  esac
+done
+
+if [ -z "${repo-}" ] || [ -z "${commit-}" ] || [ -z "${key-}" ] || [ -z "${endpoint-}" ]; then
+  die
+fi
+
+version=$("$script_dir/check-if-commit-needs-release.sh" "--repo=$repo" "--commit=$commit" |
+  sed "s/needs-release\///")
+
+if [ -z "$version" ]; then
+  echo No release tag needed
+  exit 0
+fi
+
+"$script_dir/invoke_tag_release.sh" \
+  --repo="$repo" --version="$version" --key="$key" --endpoint="$endpoint" --channel="${channel:-}"

--- a/src/remove-needs-release-labels-for-commit.sh
+++ b/src/remove-needs-release-labels-for-commit.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+set -euo pipefail
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+die() {
+  echo Usage: "$0" "--repo=<REPO> --commit=<SHA>"
+  exit 1
+}
+
+for i in "$@"; do
+  case $i in
+  -r=* | --repo=*)
+    repo="${i#*=}"
+    ;;
+  -c=* | --commit=*)
+    commit="${i#*=}"
+    ;;
+  -v=* | --version=*)
+    version="${i#*=}"
+    ;;
+  *)
+    echo "unknown option $i"
+    die
+    ;;
+  esac
+done
+
+if [ -z "${repo-}" ]; then
+  die
+fi
+
+# check that the right repo is checked out
+if [[ $(git remote get-url origin | grep -c "$repo\(\.git\)\?$") -lt 1 ]]; then
+  echo "must be run from a full checkout of $repo"
+  exit 1
+fi
+
+label_prefix="needs-release/"
+
+pr_search_string="label:"
+for v in "major" "minor" "patch"; do
+  pr_search_string="${pr_search_string}${label_prefix}$v,"
+done
+if [ -n "${version-}" ]; then
+  pr_search_string="${pr_search_string}${label_prefix}$version,"
+fi
+
+# find merged PRs with a needs-release/ label for the specified version or an auto version
+prs_needing_release=$(
+  gh pr list --repo "$repo" --state merged --search "$pr_search_string" \
+    --json number --jq '.[].number'
+)
+
+for pr in ${prs_needing_release}; do
+  # only update PRs whose merge commit is included
+  if "$script_dir/is-pr-merge-commit-ancestor-of-commit.sh" --repo="$repo" --pr="$pr" --commit="$commit"; then
+    echo "merge_commit of pr #$pr is an ancestor of released commit"
+    # find and remove all needs-release/* labels
+    to_remove=$(
+      gh pr view "$pr" --repo "$repo" --json labels --jq '.[].[].name' || echo "" |
+        grep -o "^needs-release/.*$"
+    )
+
+    echo "removing labels ($(echo -n "$to_remove" | tr '\n' ',')) from pr #$pr"
+    for label in $to_remove; do
+      gh pr edit "$pr" --remove-label "$label"
+    done
+  fi
+done

--- a/src/should-release.sh
+++ b/src/should-release.sh
@@ -1,0 +1,79 @@
+#!/bin/bash
+set -euo pipefail
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+die() {
+  echo "Indicate that this PR should be release as <version>"
+  echo Usage: "$0" "--repo=<REPO> --pr=<PR> --version=<VERSION> --release-bot-key=<KEY> --release-bot-endpoint=<ENDPOINT> [--slack-channel=<CHANNEL>]"
+  exit 1
+}
+
+for i in "$@"; do
+  case $i in
+  -r=* | --repo=*)
+    repo="${i#*=}"
+    ;;
+  -p=* | --pr=*)
+    pr="${i#*=}"
+    ;;
+  -v=* | --version=*)
+    version="${i#*=}"
+    ;;
+  -k=* | --release-bot-key=*)
+    key="${i#*=}"
+    ;;
+  -e=* | --release-bot-endpoint=*)
+    endpoint="${i#*=}"
+    ;;
+  -s=* | --slack-channel=*)
+    channel="${i#*=}"
+    ;;
+  *)
+    echo "unknown option $i"
+    die
+    ;;
+  esac
+done
+
+if [ -z "${repo-}" ] || [ -z "${pr-}" ] || [ -z "${version-}" ] || [ -z "${endpoint-}" ] || [ -z "${key-}" ]; then
+  die
+fi
+
+version_pattern="^\(major\|minor\|patch\|v[0-9]\+\.[0-9]\+\.[0-9]\+\)$"
+if [ "$(echo "$version" | grep "$version_pattern")" != "$version" ]; then
+  echo "Requested version ($version) does not match expected pattern: '$version_pattern'"
+  exit 1
+fi
+
+# refuse if it already has a release label
+labels=$(gh pr view "$pr" --repo "$repo" --json labels --jq '.labels[].name' || echo "")
+release_labels=$(echo "$labels" | grep -o "^needs-release/.*$" || echo "")
+if [ -n "$release_labels" ]; then
+  echo "Cowardly refusing to mark pr #$pr for release because it already has release label"
+  echo "Please remove label(s): $(echo "$release_labels" | tr '\n' ',') and try again"
+  exit 1
+fi
+
+# add the label
+"$script_dir/add-needs-release-label-to-pr.sh" --repo="$repo" --pr="$pr" --version="$version"
+
+# if this pr isn't merged, it can't already be built on default branch, so we're done
+if [ "$(gh pr view "$pr" --repo "$repo" --json state --jq ".state")" != "MERGED" ]; then
+  exit 0
+fi
+
+# PR is merged, so we need to check if it's already been built on the default branch
+
+# find the latest successful sha built on the default branch
+default_branch=$(gh repo view "$repo" --json defaultBranchRef --jq ".defaultBranchRef.name")
+latestVerifiedCommit=$(gh run list \
+  --repo "$repo" --workflow "$default_branch" \
+  --status success --limit 1 \
+  --json headSha --jq ".[].headSha" ||
+  echo "")
+
+# if already built on master, invoke release-bot
+if "$script_dir/is-pr-merge-commit-ancestor-of-commit.sh" --repo="$repo" --pr="$pr" --commit="$latestVerifiedCommit"; then
+  "$script_dir/invoke_tag_release.sh" \
+    --repo="$repo" --version="$version" --key="$key" --endpoint="$endpoint" --channel="$channel"
+fi

--- a/test/is-pr-commit-ancestor-of-commit.bats
+++ b/test/is-pr-commit-ancestor-of-commit.bats
@@ -1,0 +1,19 @@
+#!/usr/bin/env bats
+
+setup() {
+  # get the containing directory of this file
+  # use $BATS_TEST_FILENAME instead of ${BASH_SOURCE[0]} or $0,
+  # as those will point to the bats executable's location or the preprocessed file respectively
+  DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")" >/dev/null 2>&1 && pwd)"
+  # make executables in src/ visible to PATH
+  PATH="$DIR/../src:$PATH"
+}
+
+@test "PR is ancestor" {
+  is-pr-merge-commit-ancestor-of-commit.sh --repo=pulumi/action-release-by-pr-label --pr=1 --commit=929d87a7f7de13b44b6cf806458274089603bd52
+}
+
+@test "PR is not ancestor" {
+  run is-pr-merge-commit-ancestor-of-commit.sh --repo=pulumi/action-release-by-pr-label --pr=1 --commit=e8da7f284922fb8a2c649411bcc8ddb491ca56e3
+  [ "$status" -eq 2 ]
+}


### PR DESCRIPTION
GitHub actions to facilitate marking PRs as needing release using labels
and then triggering releases from those labels at a later point.

Basic Use:
1. Use 'should-release' command to mark a PR (with a label) as needing release
2. Use 'release-if-needed' after doing the work to verify a commit is ok to begin release (eg. at end of main/master build)
3. Use 'clean-up-release-labels' after a release build to remove labels from the PRs that were released

The advantages of this workflow are:
1. You can fully automate release after a PR is merged
2. What to release and what version number to use is still a human determination
3. needs-release/* labels provide visibility into what PRs are awaiting release, and assist in debugging the release process

Apologies for the buckets of bash, but this is a lot of glue code, so rather than shelling out from another language I've opted to just stay in bash. I've tried to make up for this by breaking out smaller helper scripts and integrating some testing facilities.