### PR TITLE
Make curl throw errors when call to release bot fails

### DIFF
--- a/src/invoke_tag_release.sh
+++ b/src/invoke_tag_release.sh
@@ -61,7 +61,10 @@ rm private_key.pem
 # some versions of openssl add this prefix which we don't need
 sed -e 's/SHA2-256(stdin)= //g' -i".bak" sig
 
-curl -v -X POST \
+# debug logging body since curl does not log it for us
+echo "INFO: calling release bot with body: '$(cat body)'" >&2
+
+curl -v --fail-with-body -X POST \
   --header "Content-Type: application/json" \
   --header "X-Signature: $(cat sig)" \
   --data-binary @body \

--- a/test/invoke-release-bot.bats
+++ b/test/invoke-release-bot.bats
@@ -1,0 +1,24 @@
+#!/usr/bin/env bats
+
+setup() {
+  # get the containing directory of this file
+  # use $BATS_TEST_FILENAME instead of ${BASH_SOURCE[0]} or $0,
+  # as those will point to the bats executable's location or the preprocessed file respectively
+  DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")" >/dev/null 2>&1 && pwd)"
+  # make executables in src/ visible to PATH
+  PATH="$DIR/../src:$PATH"
+}
+
+@test "release-bot errors are script errors" {
+  # generate a fake key so we don't error creating the signature
+  openssl genrsa -out private.pem 1024
+  # trying to post to example.com/release returns a 404
+  run invoke_tag_release.sh \
+    --repo=pulumi/foo \
+    --version=foo \
+    --key="$(cat private.pem)" \
+    --endpoint="https://example.com"
+  # cleanup key file
+  rm private.pem
+  [ "$status" -eq 22 ]
+}


### PR DESCRIPTION
Fixes #4

Also adds a debug line so we can see what we sent to release bot if it fails. 