### PR TITLE
Fix release-if-needed invoking releasebot with bad versions

### DIFF
--- a/src/check-if-commit-needs-release.sh
+++ b/src/check-if-commit-needs-release.sh
@@ -31,7 +31,7 @@ gh pr list \
   --repo "$repo" \
   --state merged \
   --search "$commit" \
-  --json labels --jq '.[].labels[].name' ||
-  echo "" |
+  --json labels --jq '.[].labels[].name' |
   grep -o "^needs-release/.*$" |
-    head -n 1
+  head -n 1 ||
+  echo ""

--- a/src/invoke_tag_release.sh
+++ b/src/invoke_tag_release.sh
@@ -42,6 +42,12 @@ if ! echo "$repo" | grep '^pulumi/.*$'; then
 fi
 repo=${repo#"pulumi/"}
 
+version_pattern="^\(major\|minor\|patch\|v[0-9]\+\.[0-9]\+\.[0-9]\+\)$"
+if [ "$(echo "$version" | grep "$version_pattern")" != "$version" ]; then
+  echo "Requested version ($version) does not match expected pattern: '$version_pattern'"
+  die
+fi
+
 tempdir=$(mktemp -d)
 cd "$tempdir"
 trap 'rm -rf "$tempdir"; cd -' EXIT

--- a/test/check-if-commit-needs-release.bats
+++ b/test/check-if-commit-needs-release.bats
@@ -1,0 +1,21 @@
+#!/usr/bin/env bats
+
+setup() {
+  # get the containing directory of this file
+  # use $BATS_TEST_FILENAME instead of ${BASH_SOURCE[0]} or $0,
+  # as those will point to the bats executable's location or the preprocessed file respectively
+  DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")" >/dev/null 2>&1 && pwd)"
+  # make executables in src/ visible to PATH
+  PATH="$DIR/../src:$PATH"
+}
+
+@test "only returns the needs-release label" {
+  # this commit is the merge commit for PR #1 which has both a release label and a spurious label
+  output=$(src/check-if-commit-needs-release.sh --repo=pulumi/action-release-by-pr-label --commit=8de77745e9d0022317fdc3efe30e4a785f93a329)
+  [ "$output" = "needs-release/v0.0.1" ]
+}
+
+@test "empty output when we can't find the PR" {
+  output=$(src/check-if-commit-needs-release.sh --repo=pulumi/action-release-by-pr-label --commit=foobar)
+  [ "$output" = "" ]
+}


### PR DESCRIPTION
Fixes https://github.com/pulumi/release-bot/issues/66

Incorrect ordering of the fallback response in `check-if-commit-needs-release.sh` meant we were skipping the filter to return just "needs-release/*" labels. Fixed the command, added a fail-fast in invoke_tag_release.sh to catch invalid versions before we call release bot, and added some tests.