### PR TITLE
Only tag the tested commit

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,7 +7,7 @@ jobs:
     name: Test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: mfinelli/setup-shfmt@v3
       - name: actionlint
         uses: raven-actions/actionlint@v1

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,15 +8,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: mfinelli/setup-shfmt@v3
-      - name: actionlint
-        uses: raven-actions/actionlint@v1
+      - uses: jdx/mise-action@v2
+        with:
+          version: 2025.5.8
       - name: Run Lint
         run: make lint
-      - name: Setup BATS
-        uses: mig4/setup-bats@v1
-        with:
-          bats-version: 1.5.0
       - name: Run Tests
         run: bats --trace --print-output-on-failure test/
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Run Lint
         run: make lint
       - name: Run Tests
-        run: bats --trace --print-output-on-failure test/
+        run: make test
 
 on:
   workflow_call:

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       # preconditions
       - name: Checkout Scripts Repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Unshallow clone for tags
         run: git fetch --prune --unshallow --tags
       - name: Label not present

--- a/.mise.toml
+++ b/.mise.toml
@@ -1,0 +1,5 @@
+[tools]
+bats = "1.5.0"
+shfmt = "3.11.0"
+actionlint = "1.7.7"
+shellcheck = "0.10.0"

--- a/src/invoke_tag_release.sh
+++ b/src/invoke_tag_release.sh
@@ -60,6 +60,8 @@ if [ -n "${channel-}" ]; then
   maybe_channel=", 'channel':'$channel'"
 fi
 
+commit=${commit#""}
+
 echo -n "{'repo': '$repo', 'version':'$version', 'timestamp':'$(date +%s)', 'commit':'$commit'$maybe_channel}" |
   tr "'" '"' >body
 

--- a/src/invoke_tag_release.sh
+++ b/src/invoke_tag_release.sh
@@ -60,7 +60,7 @@ if [ -n "${channel-}" ]; then
   maybe_channel=", 'channel':'$channel'"
 fi
 
-commit=${commit#""}
+commit=${commit:-}
 
 echo -n "{'repo': '$repo', 'version':'$version', 'timestamp':'$(date +%s)', 'commit':'$commit'$maybe_channel}" |
   tr "'" '"' >body

--- a/src/invoke_tag_release.sh
+++ b/src/invoke_tag_release.sh
@@ -24,6 +24,9 @@ for i in "$@"; do
   -c=* | --channel=*)
     channel="${i#*=}"
     ;;
+  --commit=*)
+    commit="${i#*=}"
+    ;;
   *)
     echo "unknown option $i"
     die
@@ -57,7 +60,7 @@ if [ -n "${channel-}" ]; then
   maybe_channel=", 'channel':'$channel'"
 fi
 
-echo -n "{'repo': '$repo', 'version':'$version', 'timestamp':'$(date +%s)'$maybe_channel}" |
+echo -n "{'repo': '$repo', 'version':'$version', 'timestamp':'$(date +%s)', 'commit':'$commit'$maybe_channel}" |
   tr "'" '"' >body
 
 echo "$key" >private_key.pem
@@ -70,7 +73,7 @@ sed -e 's/SHA2-256(stdin)= //g' -i".bak" sig
 # debug logging body since curl does not log it for us
 echo "INFO: calling release bot with body: '$(cat body)'" >&2
 
-curl -v --fail-with-body -X POST \
+curl -v --fail-with-body \
   --header "Content-Type: application/json" \
   --header "X-Signature: $(cat sig)" \
   --data-binary @body \

--- a/src/release-if-needed.sh
+++ b/src/release-if-needed.sh
@@ -46,4 +46,4 @@ if [ -z "$version" ]; then
 fi
 
 "$script_dir/invoke_tag_release.sh" \
-  --repo="$repo" --version="$version" --key="$key" --endpoint="$endpoint" --channel="${channel:-}"
+  --repo="$repo" --version="$version" --key="$key" --endpoint="$endpoint" --channel="${channel:-}" --commit="${commit:-}"

--- a/src/release-if-needed.sh
+++ b/src/release-if-needed.sh
@@ -46,4 +46,4 @@ if [ -z "$version" ]; then
 fi
 
 "$script_dir/invoke_tag_release.sh" \
-  --repo="$repo" --version="$version" --key="$key" --endpoint="$endpoint" --channel="${channel:-}" --commit="${commit:-}"
+  --repo="$repo" --version="$version" --key="$key" --endpoint="$endpoint" --channel="${channel:-}" --commit="${commit}"


### PR DESCRIPTION
This modifies the action to take advantage of https://github.com/pulumi/release-bot/pull/78

In particular we will now pass along the commit under test so that it's guaranteed to be tagged, instead of whatever commit happens to be latest.

Fixes https://github.com/pulumi/action-release-by-pr-label/issues/14